### PR TITLE
correction for about_EventLogs

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -175,9 +175,10 @@ The Turn On Module Logging group policy setting is located in the following
 Group Policy paths:
 
 Computer Configuration\Administrative Templates\Windows Components\Windows PowerShell
+
 User Configuration\Administrative Templates\Windows Components\Windows PowerShell
 
-The User Configuration policy takes precedence over the Computer Configuration policy,
+The Computer Configuration policy takes precedence over the User Configuration policy,
 and both policies take preference over the value of the LogPipelineExecutionDetails
 property of modules and snap-ins.
 


### PR DESCRIPTION
Documentation window in gpedit.msc for PowerShell v5.0 states that Computer configuration takes precedence over User configuration for PowerShell GPO settings.  

Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [x ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

